### PR TITLE
修复IE6下日期控件遮不住下面select元素的bug

### DIFF
--- a/src/base-calendar.js
+++ b/src/base-calendar.js
@@ -107,7 +107,7 @@ var BaseCalendar = Widget.extend({
       this.set('lang', langs[this.get('lang')]);
     }
 
-    this._shim = new Shim(this.element);//.sync();
+    this._shim = new Shim(this.element);
 
     var self = this;
 
@@ -200,11 +200,11 @@ var BaseCalendar = Widget.extend({
     var event = this.get('triggerType') + '.calendar';
     $trigger.on(event, function() {
       self.show();
-	  self._shim.sync();
+      self._shim.sync();
     });
     $trigger.on('blur.calendar', function() {
       self.hide();
-	  self._shim.sync();
+      self._shim.sync();
     });
     // enable auto hide feature
     if ($trigger[0].tagName.toLowerCase() !== 'input') {


### PR DESCRIPTION
问题描述：base-calendar.js:110，实例化Shim对象时日期控件弹出层还没有生成，因此iframe-shim获取不到弹出层的宽度，导致Shim控件失效，日期控件弹出层遮挡不住其下面的select元素。

修复方法：实例化Shim对象时不立即调用sync方法，在日期控件显示时调用即可
